### PR TITLE
Fix broken test and pass creds through env

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -38,12 +38,11 @@ Running the Unit Tests
     $ git clone git@github.com:cgoldberg/sauceclient.git
     $ cd sauceclient
 
- * edit ``test_sauceclient.py``, and change the 
-   test parameters to match your Sauce Labs account info::
+* set the following environment variables::
 
-    SAUCE_USERNAME = 'your-username-string'
-    SAUCE_ACCESS_KEY = 'your-access-key-string'
-    TEST_JOB_ID = 'a-valid-test-job-id'
+    $ export SAUCE_USERNAME='your-username-string'
+    $ export SAUCE_ACCESS_KEY='your-access-key-string'
+    $ export TEST_JOB_ID='a-valid-test-job-id'
 
  * run tests by executing ``test_sauceclient.py``, or using ``unittest`` discovery::
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -38,7 +38,7 @@ Running the Unit Tests
     $ git clone git@github.com:cgoldberg/sauceclient.git
     $ cd sauceclient
 
-* set the following environment variables::
+ * set the following environment variables::
 
     $ export SAUCE_USERNAME='your-username-string'
     $ export SAUCE_ACCESS_KEY='your-access-key-string'

--- a/test_sauceclient.py
+++ b/test_sauceclient.py
@@ -12,7 +12,7 @@
 #       http://www.apache.org/licenses/LICENSE-2.0
 #
 
-
+import os
 import random
 import unittest
 
@@ -20,9 +20,9 @@ import sauceclient
 
 
 # set these to run tests
-SAUCE_USERNAME = ''
-SAUCE_ACCESS_KEY = ''
-TEST_JOB_ID = ''  # any valid job
+SAUCE_USERNAME = os.environ.get('SAUCE_USERNAME', '')
+SAUCE_ACCESS_KEY = os.environ.get('SAUCE_ACCESS_KEY', '')
+TEST_JOB_ID = os.environ.get('TEST_JOB_ID', '')  # any valid job
 
 
 class TestSauceClient(unittest.TestCase):
@@ -167,7 +167,6 @@ class TestInformation(unittest.TestCase):
         self.assertIn('long_name', browser)
         self.assertIn('long_version', browser)
         self.assertIn('os', browser)
-        self.assertIn('preferred_version', browser)
         self.assertIn('selenium_name', browser)
         self.assertIn('short_version', browser)
         self.assertIsInstance(browser['selenium_name'], unicode)


### PR DESCRIPTION
Removes the check for preferred_version, which isn't present in
Sauce anymore.

Allow user to specify SAUCE_USERNAME, SAUCE_ACCESS_KEY, TEST_JOB_ID
by environment variable.
