### PR TITLE
Add optional support for installing package in development mode

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -7,6 +7,7 @@ Requirements
 
  * Python 2.7
  * git
+ * setuptools (optional)
 
 Source Code Repository (GitHub)
 ===============================
@@ -30,8 +31,11 @@ Clone the Repository:
     $ git clone https://github.com/cgoldberg/sauceclient.git
 
 
-Install package in development mode
-===================================
+Install package in development mode (optional)
+==============================================
+
+Note: you must have the `setuptools` Python package installed on your local
+machine to install `sauceclient` in development mode.
 
  * clone the repo::
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -30,6 +30,26 @@ Clone the Repository:
     $ git clone https://github.com/cgoldberg/sauceclient.git
 
 
+Install package in development mode
+===================================
+
+ * clone the repo::
+
+    $ git clone git@github.com:cgoldberg/sauceclient.git
+    $ cd sauceclient
+
+ * install `sauceclient` in development mode::
+
+    $ python setup.py develop
+
+Now, you can make changes directly to the source files in the original location
+where you cloned the git repository, and those changes will be reflected
+immediately when you use `sauceclient` in your Python scripts. See
+`Development Mode`_ in the `setuptools` documentation for more details.
+
+.. _Development Mode:  http://peak.telecommunity.com/DevCenter/setuptools#development-mode
+
+
 Running the Unit Tests
 ======================
 
@@ -38,7 +58,7 @@ Running the Unit Tests
     $ git clone git@github.com:cgoldberg/sauceclient.git
     $ cd sauceclient
 
- * edit ``test_sauceclient.py``, and change the 
+ * edit ``test_sauceclient.py``, and change the
    test parameters to match your Sauce Labs account info::
 
     SAUCE_USERNAME = 'your-username-string'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 
 
 import os
-from distutils.core import setup
+from setuptools import setup
 
 this_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_dir, 'README.rst')) as f:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,13 @@
 
 
 import os
-from setuptools import setup
+
+# Use setuptools if it's available, fall back to distutils if not
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 
 this_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_dir, 'README.rst')) as f:


### PR DESCRIPTION
Add support for allowing developer to install package in development mode:

```
python setup.py develop
```

Installing in development mode requires setuptools. If it's not present, then installer will fall back to distutils.
