### PR TITLE
Add Jobs.get_auth_token method

### DIFF
--- a/sauceclient.py
+++ b/sauceclient.py
@@ -18,6 +18,8 @@
 
 
 import base64
+import hashlib
+import hmac
 import httplib
 import json
 
@@ -110,6 +112,15 @@ class Jobs(object):
         json_data = self.client.request(method, url, body=body)
         attributes = json.loads(json_data)
         return attributes
+
+    def get_auth_token(self, job_id):
+        """Return an authentication token associated with the job.
+
+        See: <http://saucelabs.com/docs/integration#public-job-links>
+        """
+        key = "%s:%s" % (self.client.sauce_username,
+                         self.client.sauce_access_key)
+        return hmac.new(key, job_id, hashlib.md5).hexdigest()
 
 
 class Provisioning(object):

--- a/test_sauceclient.py
+++ b/test_sauceclient.py
@@ -13,7 +13,8 @@
 #
 
 
-import random
+import httplib
+import osimport random
 import unittest
 
 import sauceclient
@@ -107,6 +108,14 @@ class TestJobs(unittest.TestCase):
         self.assertIn('id', job_attributes)
         self.assertEqual(job_attributes['id'], TEST_JOB_ID)
 
+    def test_get_auth_token(self):
+        """Verify that the auth token is valid."""
+        token = self.sc.jobs.get_auth_token(TEST_JOB_ID)
+        url = '/jobs/%s?auth=%s' % (TEST_JOB_ID, token)
+        connection = httplib.HTTPSConnection('saucelabs.com')
+        connection.request('GET', url, None)
+        response = connection.getresponse()
+        self.assertEqual(response.status, 200)
 
 class TestProvisioning(unittest.TestCase):
 


### PR DESCRIPTION
Add a method for generating an auth token that can allow anonymous
users to access a Sauce Labs jobs page.

See: http://saucelabs.com/docs/integration#public-job-links
