### PR TITLE
This version works in both Python 2 and Python 3

### DIFF
--- a/sauceclient.py
+++ b/sauceclient.py
@@ -18,11 +18,15 @@
 
 
 import base64
-import httplib
 import json
+from sys import version_info
+if version_info.major >= 3:
+    import http.client as httplib
+else:
+    import httplib
 
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 class SauceClient(object):


### PR DESCRIPTION
The `httplib` library has been renamed to `http.client` in Python 3. That's the only blocker preventing this client from working in Python 3.
