### PR TITLE
Fixed decode error in get_job_assets() when using Python 3.

### DIFF
--- a/sauceclient.py
+++ b/sauceclient.py
@@ -137,7 +137,7 @@ class Jobs(object):
         url = '/rest/v1/%s/jobs/%s/assets' % (self.client.sauce_username,
                                               job_id)
         json_data = self.client.request(method, url)
-        assets = json.loads(json_data)
+        assets = json_loads(json_data)
         return assets
 
 


### PR DESCRIPTION
In the method **get_job_assets()**, JSON data was being loaded with **json.loads()** instead of **json_loads()** causing the response to fail in Python 3.  Quick fix does the trick. ;)

For reference, the error was: 

> TypeError: the JSON object must be str, not 'bytes'