### PR TITLE
Adding get_job() method and test.

### DIFF
--- a/sauceclient.py
+++ b/sauceclient.py
@@ -261,6 +261,13 @@ class Jobs(object):
             endpoint = '?'.join([endpoint, urlencode(data)])
         return self.client.request(method, endpoint)
 
+    def get_job(self, job_id):
+        """Retreive a single job."""
+        method = 'GET'
+        endpoint = '/rest/v1/{}/jobs/{}'.format(self.client.sauce_username,
+                                                job_id)
+        return self.client.request(method, endpoint)
+
     def update_job(self, job_id, build=None, custom_data=None,
                    name=None, passed=None, public=None, tags=None):
         """Edit an existing job."""

--- a/tests.py
+++ b/tests.py
@@ -160,6 +160,14 @@ class TestSauce(unittest.TestCase):
                                      output_format='json')
         self.assertIsInstance(resp, list)
 
+    def test_jobs_get_job(self, mocked):
+        mocked.return_value.status = 200
+        mocked.return_value.reason = 'OK'
+        mocked.return_value.read.return_value = b'{}'
+
+        resp = self.sc.jobs.get_job('job-id')
+        self.assertIsInstance(resp, dict)
+
     def test_jobs_update_job(self, mocked):
         mocked.return_value.status = 200
         mocked.return_value.reason = 'OK'


### PR DESCRIPTION
Retrieving a single job is suspiciously missing from Sauce's REST API documentation:
https://wiki.saucelabs.com/display/DOCS/Job+Methods

...And therefore never got implemented in my update to sauceclient. The previous client version had `get_job _attributes()`. I have re-added this method, though renamed it `get_job()`.

-Drew