### PR TITLE
Add overwrite parameter to Storage/upload_file

### DIFF
--- a/sauceclient.py
+++ b/sauceclient.py
@@ -345,12 +345,17 @@ class Storage(object):
         """Initialize class."""
         self.client = client
 
-    def upload_file(self, filepath):
+    def upload_file(self, filepath, overwrite=None):
         """Uploads a file to the temporary sauce storage."""
         method = 'POST'
         filename = os.path.split(filepath)
         endpoint = '/rest/v1/storage/{}/{}'.format(
             self.client.sauce_username, filename)
+        data = {}
+        if overwrite:
+            data['overwrite'] = overwrite
+        if data:
+            endpoint = '?'.join([endpoint, urlencode(data)])
         with open(filepath, 'rb') as filehandle:
             body = filehandle.read()
         return self.client.request(method, endpoint, body,


### PR DESCRIPTION
I notice that by default the saucelabs set overwrite to false when call the API to upload an app in temporary storage. So , currently there is no option to overwrite an app in temporary storage. I have add a new param to be able to do that if required.
I have notice that if you try to overwrite an existing file in temporary storage you get an exception. Do you think that some type of handling is required  for these situations? 