### PR TITLE
Add overwrite argument to upload_file

### DIFF
--- a/sauceclient.py
+++ b/sauceclient.py
@@ -340,12 +340,12 @@ class Storage(object):
         """Initialize class."""
         self.client = client
 
-    def upload_file(self, filepath):
+    def upload_file(self, filepath, overwrite=True):
         """Uploads a file to the temporary sauce storage."""
         method = 'POST'
         filename = os.path.split(filepath)[1]
-        endpoint = '/rest/v1/storage/{}/{}'.format(
-            self.client.sauce_username, filename)
+        endpoint = '/rest/v1/storage/{}/{}?overwrite={}'.format(
+            self.client.sauce_username, filename, "true" if overwrite else "false")
         with open(filepath, 'rb') as filehandle:
             body = filehandle.read()
         return self.client.request(method, endpoint, body,


### PR DESCRIPTION
Because saucelabs deletes files after 7 days, we would like to reupload the file each time a test is run. After the first upload, there is an error to try to upload it again. Passing overwrite=true allows the file to be replaced.