### PR TITLE
Allow to filter jobs by job name

### DIFF
--- a/sauceclient.py
+++ b/sauceclient.py
@@ -401,7 +401,7 @@ class Jobs(object):
         self.client = client
 
     def get_jobs(self, full=None, limit=None, skip=None, start=None, end=None,
-                 output_format=None):
+                 job_name=None, output_format=None):
         """List jobs belonging to a specific user."""
         method = 'GET'
         endpoint = '/rest/v1/{}/jobs'.format(self.client.sauce_username)
@@ -412,6 +412,8 @@ class Jobs(object):
             data['limit'] = limit
         if skip is not None:
             data['skip'] = skip
+        if job_name is not None:
+            data['name'] = job_name
         if start is not None:
             data['from'] = start
         if end is not None:

--- a/tests.py
+++ b/tests.py
@@ -216,7 +216,7 @@ class TestSauce(unittest.TestCase):
 
         resp = self.sc.jobs.get_jobs(full=True, limit=1, skip=1,
                                      start=214891200, end=214975439,
-                                     output_format='json')
+                                     job_name='test_job', output_format='json')
         self.assertIsInstance(resp, list)
 
     def test_jobs_get_job(self, mocked):


### PR DESCRIPTION
There is a possibility to filter jobs my job name in `GET /rest/v1/USERNAME/jobs` endpoint, although this parameter is not present in official docs (will try to update it as well).
I encountered a use case that it would be great to have this feature.